### PR TITLE
Server metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ Returns a the newly created `Site` object or throws an exception if errors occur
 $newSite = $server->addSite($site_name, $project_type = 'php', $directory = '/public', $wildcards = false);
 ```
 
+### Update Metadata
+
+Update the metadata of the current site, and return an update collection of the `Site` object or throws an exception if errors occur.
+
+```php
+$server = $server->updateMetadata($server_name, $ip_address, $private_ip_address, $size);
+```
+
 ### Get Schedules Jobs
 
 Returns a Collection of `ScheduledJob` objects for the server.

--- a/src/Mpociot/Blacksmith/Browser.php
+++ b/src/Mpociot/Blacksmith/Browser.php
@@ -68,10 +68,10 @@ class Browser
         if ($this->logged_in === false) {
             $this->login();
         }
-        
+
         $this->session->visit($url);
         $content = $this->session->getPage()->getContent();
-        
+
         if ($raw) {
             return $content;
         }
@@ -91,6 +91,22 @@ class Browser
         }
 
         $this->session->getDriver()->post($url, json_encode($payload));
+        return json_decode($this->session->getPage()->getContent(), true);
+    }
+
+    /**
+     * @param $url
+     * @param $payload
+     * @return mixed
+     * @throws Exception
+     */
+    public function putContent($url, $payload)
+    {
+        if ($this->logged_in === false) {
+            $this->login();
+        }
+
+        $this->session->getDriver()->put($url, json_encode($payload));
         return json_decode($this->session->getPage()->getContent(), true);
     }
 

--- a/src/Mpociot/Blacksmith/Driver/BlacksmithDriver.php
+++ b/src/Mpociot/Blacksmith/Driver/BlacksmithDriver.php
@@ -17,4 +17,16 @@ class BlacksmithDriver extends GoutteDriver
             'HTTP_X_XSRF_TOKEN' => $this->getClient()->getCookieJar()->get('XSRF-TOKEN')->getValue()
         ], $postData);
     }
+
+    /**
+     * Perform a PUT request
+     */
+    public function put($url, $postData)
+    {
+        $this->getClient()->request('PUT', $this->prepareUrl($url), [], [], [
+            'HTTP_ACCEPT' => 'application/json',
+            'HTTP_CONTENT_TYPE' => 'application/json',
+            'HTTP_X_XSRF_TOKEN' => $this->getClient()->getCookieJar()->get('XSRF-TOKEN')->getValue()
+        ], $postData);
+    }
 }

--- a/src/Mpociot/Blacksmith/Models/ForgeModel.php
+++ b/src/Mpociot/Blacksmith/Models/ForgeModel.php
@@ -26,6 +26,11 @@ abstract class ForgeModel
         $this->build();
     }
 
+    public function __get($key)
+    {
+        return $this->data->get($key);
+    }
+
     protected function build()
     {
         $this->data->each(function ($value, $property) {

--- a/src/Mpociot/Blacksmith/Models/Server.php
+++ b/src/Mpociot/Blacksmith/Models/Server.php
@@ -102,4 +102,32 @@ class Server extends ForgeModel
 
         return new Site($result, $this->browser);
     }
+
+    /**
+     * Create a new site on this server.
+     *
+     * @param string $name
+     * @param string $ip_address
+     * @param string $private_ip_address
+     * @param integer $size
+     * @return Site
+     * @throws Exception
+     */
+    public function updateMetadata($server_name, $ip_address, $private_ip_address, $size)
+    {
+        $result = $this->browser->putContent('https://forge.laravel.com/servers/'.$this->id.'/meta', [
+            "name" => $server_name,
+            "ip_address" => $ip_address,
+            "private_ip_address" => $private_ip_address,
+            "size" => intval($size),
+        ]);
+
+        if ($this->browser->getSession()->getStatusCode() === 500) {
+            throw new Exception('Error: '.print_r($result, true));
+        }
+
+        $this->data = $this->data->merge($result);
+
+        return $this;
+    }
 }


### PR DESCRIPTION
I have added and tested the ability to update the servers metadata

This data is;
- Server Name
- IP Address
- Private IP Address
- Ram Size (GB)

Code to use it;
```php
$blacksmith = new Blacksmith($email, $password);

$server = $blacksmith->getServer(1234);

$name = "test server";
$ip_address = "8.8.8.8";
$private_ip_address = "192.168.10.10";
$size = 4;

$server = $server->updateMetadata($name, $ip_address, $private_ip_address, $size);
```

I have also added the magic `__get` method to the `ForgeModel` so that we can get data as so

```php
var_dump($server->ip_address);
```

This PR is to address issue #2 