### PR TITLE
Added deleteSite method

### DIFF
--- a/src/Mpociot/Blacksmith/Blacksmith.php
+++ b/src/Mpociot/Blacksmith/Blacksmith.php
@@ -87,6 +87,20 @@ class Blacksmith
         $siteData = $this->browser->getContent('https://forge.laravel.com/api/servers/'.$site['server_id'].'/sites/'.$site['id'])->toArray();
         return new Site($siteData, $this->browser);
     }
+    
+    /**
+     * Delete site
+     *
+     * @param $identifier
+     * @return mixed
+     * @throws Exception
+     */
+    public function deleteSite($identifier)
+    {
+        $site = $this->getSite($identifier);
+        return $this->browser->deleteContent('https://forge.laravel.com/api/servers/'.$site->server_id.'/sites/'.$site->id);
+    }
+
 
     /**
      * Get all available sites


### PR DESCRIPTION
This PR adds a new `deleteSite($identifier)` method to Blacksmith.

The background behind this is that I needed functionality in my build pipeline to build review sites based on feature branches. When a branch is created a new site in Forge is created. When a branch is deleted the site is also deleted.